### PR TITLE
Fix ability selected bug

### DIFF
--- a/js/abilities.js
+++ b/js/abilities.js
@@ -83,6 +83,10 @@ var abilitiesManagement = {
             if (this.cardsInHand.includes(card)) {
                 indexOfCardToRemove = this.cardsInHand.indexOf(card);
                 this.cardsInHand.splice(indexOfCardToRemove, 1);
+                if(this.twoAbilitiesSelected.includes(card)){
+                    indexOfCardToRemove = this.twoAbilitiesSelected.indexOf(card);
+                    this.twoAbilitiesSelected.splice(indexOfCardToRemove, 1);
+                }
             } else if (this.cardsDestroyed.includes(card)) {
                 indexOfCardToRemove = this.cardsDestroyed.indexOf(card);
                 this.cardsDestroyed.splice(indexOfCardToRemove, 1);


### PR DESCRIPTION
Fix this scenario :
1- User select two cards to play
2- User goes back to the abilities tab
3- User unselect the cards he previously selected in the play tab

KO : The user is not able to select cards to play anymore