### PR TITLE
Update Geminate to 14 card deck

### DIFF
--- a/js/database_frosthaven.js
+++ b/js/database_frosthaven.js
@@ -1568,7 +1568,7 @@ abilities_frosthaven = [
     },
     {
         "name": "ge",
-        "max": 7,
+        "max": 14,
         "hidden": false,
         "position": 5,
         "cards": [


### PR DESCRIPTION
Geminate has two 7 card decks.  To be able to use this app with the geminate they need to have a 14 card hand.