### PR TITLE
Remove duplicate card

### DIFF
--- a/js/database_frosthaven.js
+++ b/js/database_frosthaven.js
@@ -4427,17 +4427,6 @@ abilities_frosthaven = [
           "character-xws": "trapper"
         },
         {
-          "name": "shaggy lure",
-          "points": 1167,
-          "expansion": "Frosthaven",
-          "image": "character-ability-cards/frosthaven/TA/fh-furry-facade.png",
-          "xws": "furryfacade",
-          "level": "1",
-          "initiative": "85",
-          "cardno": "274",
-          "character-xws": "trapper"
-        },
-        {
           "name": "grasping hazards",
           "points": 1168,
           "expansion": "Frosthaven",


### PR DESCRIPTION
In my previous PR (#272) I had copy-pasted the card list from https://github.com/any2cards/worldhaven/blob/master/data/character-ability-cards.js.

I just realized that this had 2 copies of the same card.
I'm guessing that shaggy lure was renamed as furry facade at some point.

You can leave this PR open if you want and I'll confirm the published card name when I get the box again on Saturday